### PR TITLE
Fix segfaults inside g_free on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,6 @@ jobs:
           echo "Sleeping 180.0 seconds until booted (boot process took 118s first time)"
           Start-Sleep -Seconds 180.0
           echo "Stopping process"
-          Stop-Process -Id $process.id
+          Stop-Process -Id $process.id -ErrorAction SilentlyContinue
           cat out.txt
           cat err.txt

--- a/qemu-plugin/Cargo.toml
+++ b/qemu-plugin/Cargo.toml
@@ -17,6 +17,11 @@ once_cell = "1.19.0"
 qemu-plugin-sys = { version = "8.2.2-v0", workspace = true }
 thiserror = "1.0.51"
 
+[target.'cfg(windows)'.dependencies.libloading]
+version = "0.8.3"
+[target.'cfg(windows)'.dependencies.lazy_static]
+version = "1.4"
+
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.52"
 features = [


### PR DESCRIPTION
This should fix #13.

calling `libc::free` actually doesn't always work, because there are multiple heaps, and we're trying to free it from the wrong one.

Instead, we find the g_free export from libglib-2.0, and invoke that.

Added the `libloading` crate to help with this, and also rewrote the `delaylink_hook` to use the functions there, rather than directly calling the windows API.