### PR TITLE
mem: fix memory corruption when reading guest vaddr

### DIFF
--- a/qemu-plugin/src/memory/mod.rs
+++ b/qemu-plugin/src/memory/mod.rs
@@ -13,6 +13,13 @@ use crate::Result;
     feature = "plugin-api-v0",
     feature = "plugin-api-v1",
     feature = "plugin-api-v2",
+    feature = "plugin-api-v3"
+)))]
+use crate::glib::{g_byte_array_free, g_byte_array_new};
+#[cfg(not(any(
+    feature = "plugin-api-v0",
+    feature = "plugin-api-v1",
+    feature = "plugin-api-v2",
     feature = "plugin-api-v3",
     feature = "plugin-api-v4"
 )))]
@@ -205,22 +212,40 @@ impl<'a> HwAddr<'a> {
 )))]
 /// Read memory from a virtual address. The address must be valid and mapped.
 pub fn qemu_plugin_read_memory_vaddr(addr: u64, buf: &mut [u8]) -> Result<()> {
-    let mut buf = GByteArray {
-        data: buf.as_mut_ptr(),
-        len: buf.len() as u32,
-    };
-
-    if unsafe {
-        crate::sys::qemu_plugin_read_memory_vaddr(
+    let mut g_buf = unsafe { g_byte_array_new() };
+    if g_buf.is_null() {
+        return Err(Error::VaddrReadError {
             addr,
-            &mut buf as *mut GByteArray,
-            buf.len as usize,
-        )
-    } {
+            len: buf.len() as u32,
+        });
+    }
+
+    let res = if unsafe { crate::sys::qemu_plugin_read_memory_vaddr(addr, g_buf, buf.len()) } {
+        // Upon success, copy the gbuf contents to the output slice
+        // SAFETY: qemu_plugin_read_memory_vaddr will ensure that the
+        // input g_buf has the proper size. We also use `buf.len()` as
+        // the upper bound, so worst case scenario it's uninit mem being
+        // copied into the output buffer (but that shouldn't happen!).
+        unsafe {
+            assert_eq!((*g_buf).len as usize, buf.len());
+            std::ptr::copy((*g_buf).data, buf.as_mut_ptr(), buf.len());
+        }
+
         Ok(())
     } else {
-        Err(Error::VaddrReadError { addr, len: buf.len })
+        Err(Error::VaddrReadError {
+            addr,
+            len: buf.len() as u32,
+        })
+    };
+
+    // SAFETY: `true` here will free the backing bytes if the refcount drops to zero,
+    // but they've already been copied to the caller's buffer.
+    unsafe {
+        g_byte_array_free(g_buf, true);
     }
+
+    res
 }
 
 #[cfg(not(any(


### PR DESCRIPTION
While testing my plugin I was experiencing frequent hangs with call stacks like:

```
(lldb) bt
* thread #11, stop reason = EXC_BAD_ACCESS (code=2, address=0x1e6a3720c)
  * frame #0: 0x0000000188afe050 libsystem_platform.dylib`__bzero + 32
    frame #1: 0x0000000103807fac libglib-2.0.0.dylib`g_array_set_size + 136
    frame #2: 0x0000000103809c00 libglib-2.0.0.dylib`g_byte_array_set_size + 20
    frame #3: 0x00000001024c7f8c xemu`qemu_plugin_read_memory_vaddr(addr=9582356, data=0x000000016e31e598, len=<unavailable>) at api.c:571:5 [opt]
    frame #4: 0x000000011e1d44ec libsplinter_cell_qemu_plugin.dylib`qemu_plugin::memory::qemu_plugin_read_memory_vaddr::h9ff5b36bf22ea5d5(addr=9582356, buf=(data_ptr = "", length = 4)) at mod.rs:214:9
    frame #5: 0x000000011e1ca9b0 libsplinter_cell_qemu_plugin.dylib`_$LT$splinter_cell_qemu_plugin..SplinterCellDumper$u20$as$u20$qemu_plugin..plugin..HasCallbacks$GT$::on_translation_block_translate::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::he7f008294245bb95(vcpu=0) at lib.rs:118:25
    frame #6: 0x000000011e1c7d74 libsplinter_cell_qemu_plugin.dylib`_$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnMut$LT$Args$GT$$GT$::call_mut::h94c7af4678ae8d40(self=0x0000000bdb697fa0, args=(__0 = 0)) at boxed.rs:1992:9
```

Or occasionally I'd `SIGSEGV`.

While walking through this code, I noticed that `GByteArray` gets cast to a `GRealArray` which has a _much bigger_ size than `GByteArray`: https://gitlab.gnome.org/GNOME/glib/-/blob/91524a98c54e57f1b609d95131480bdd15ebb43f/glib/garray.c#L768

The `GByteArray` is defined as a smaller size as not to reveal internal details of `GRealArray`. This means that the current implementation will trigger an out-of-bounds read/write when attempting to set the array size.

The correct way of interfacing with these APIs is to have glib construct the `GByteArray`, then pass that pointer to these APIs.

With this patch my plugin now works as expected.

Note: a similar bug exists in `qemu_plugin_read_memory_hwaddr` but I have not yet tested an equivalent fix for that.