### PR TITLE
qemu-plugin: implement the atexit_cb() functionality

### DIFF
--- a/plugins/tiny/src/lib.rs
+++ b/plugins/tiny/src/lib.rs
@@ -38,6 +38,11 @@ impl HasCallbacks for TinyTrace {
             Ok(())
         })
     }
+
+    fn on_exit(&mut self, id: PluginId) -> Result<()> {
+        println!("TinyTrace::on_exit() for id {}", id);
+        Ok(())
+    }
 }
 
 register!(TinyTrace::default());

--- a/qemu-plugin/src/lib.rs
+++ b/qemu-plugin/src/lib.rs
@@ -65,8 +65,8 @@ mod win_link_hook;
 use crate::sys::{
     qemu_plugin_cb_flags, qemu_plugin_id_t, qemu_plugin_insn, qemu_plugin_mem_rw,
     qemu_plugin_meminfo_t, qemu_plugin_op, qemu_plugin_simple_cb_t, qemu_plugin_tb,
-    qemu_plugin_vcpu_simple_cb_t, qemu_plugin_vcpu_syscall_cb_t, qemu_plugin_vcpu_syscall_ret_cb_t,
-    qemu_plugin_vcpu_tb_trans_cb_t,
+    qemu_plugin_udata_cb_t, qemu_plugin_vcpu_simple_cb_t, qemu_plugin_vcpu_syscall_cb_t,
+    qemu_plugin_vcpu_syscall_ret_cb_t, qemu_plugin_vcpu_tb_trans_cb_t,
 };
 #[cfg(not(any(feature = "plugin-api-v0", feature = "plugin-api-v1")))]
 use crate::sys::{qemu_plugin_reg_descriptor, qemu_plugin_u64};
@@ -209,6 +209,13 @@ pub type SyscallCallback = qemu_plugin_vcpu_syscall_cb_t;
 /// - `num`: The syscall number
 /// - `ret`: The syscall return value
 pub type SyscallReturnCallback = qemu_plugin_vcpu_syscall_ret_cb_t;
+
+/// A callback called when execution has finished and the plugin should free its resources
+///
+/// # Arguments
+///
+/// - `id`: The plugin ID
+pub type AtExitCallback = qemu_plugin_udata_cb_t;
 
 // NOTE: Box<Box< is not strictly necessary here because the pointer is never sent via
 // FFI which means we never downcast to an 8-byte pointer from fat, but it is best not

--- a/qemu-plugin/src/plugin/mod.rs
+++ b/qemu-plugin/src/plugin/mod.rs
@@ -4,10 +4,11 @@ use std::sync::{Mutex, OnceLock};
 
 use crate::{
     Args, Error, Info, PluginId, Result, TranslationBlock, VCPUIndex,
-    qemu_plugin_register_flush_cb, qemu_plugin_register_vcpu_exit_cb,
-    qemu_plugin_register_vcpu_idle_cb, qemu_plugin_register_vcpu_init_cb,
-    qemu_plugin_register_vcpu_resume_cb, qemu_plugin_register_vcpu_syscall_cb,
-    qemu_plugin_register_vcpu_syscall_ret_cb, qemu_plugin_register_vcpu_tb_trans_cb,
+    qemu_plugin_register_atexit_cb, qemu_plugin_register_flush_cb,
+    qemu_plugin_register_vcpu_exit_cb, qemu_plugin_register_vcpu_idle_cb,
+    qemu_plugin_register_vcpu_init_cb, qemu_plugin_register_vcpu_resume_cb,
+    qemu_plugin_register_vcpu_syscall_cb, qemu_plugin_register_vcpu_syscall_ret_cb,
+    qemu_plugin_register_vcpu_tb_trans_cb,
 };
 
 /// Handler for callbacks registered via the `qemu_plugin_register_vcpu_init_cb`
@@ -115,6 +116,22 @@ extern "C" fn handle_qemu_plugin_register_flush_cb(id: PluginId) {
     plugin
         .on_flush(id)
         .expect("Failed running callback on_flush");
+}
+
+/// Handler for callbacks registered via the `qemu_plugin_register_atexit_cb`
+/// function. These callbacks are called when execution has finished and plugins
+/// should free their resources.
+extern "C" fn handle_qemu_plugin_register_atexit_cb(id: PluginId, _udata: *mut std::ffi::c_void) {
+    // We don't actually need the userdata here, and we pass std::ptr::null_mut() when registering.
+    let Some(plugin) = PLUGIN.get() else {
+        panic!("Plugin not set");
+    };
+
+    let Ok(mut plugin) = plugin.lock() else {
+        panic!("Failed to lock plugin");
+    };
+
+    plugin.on_exit(id).expect("Failed running callback on_exit");
 }
 
 /// Handler for callbacks registered via the `qemu_plugin_register_vcpu_syscall_cb`
@@ -250,6 +267,10 @@ pub trait Register: HasCallbacks + Send + Sync + 'static {
 
         qemu_plugin_register_flush_cb(id, Some(handle_qemu_plugin_register_flush_cb));
 
+        qemu_plugin_register_atexit_cb(id, |id| {
+            handle_qemu_plugin_register_atexit_cb(id, std::ptr::null_mut());
+        });
+
         qemu_plugin_register_vcpu_syscall_cb(id, Some(handle_qemu_plugin_register_syscall_cb));
 
         qemu_plugin_register_vcpu_syscall_ret_cb(
@@ -366,6 +387,16 @@ pub trait HasCallbacks: Send + Sync + 'static {
     ///
     /// * `id` - The ID of the plugin
     fn on_flush(&mut self, id: PluginId) -> Result<()> {
+        Ok(())
+    }
+
+    #[allow(unused)]
+    /// Callback triggered on exit
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The ID of the plugin
+    fn on_exit(&mut self, id: PluginId) -> Result<()> {
         Ok(())
     }
 


### PR DESCRIPTION
Based on the existing code for other callback handlers, add the _atexit_cb() handling, so that plugins can implement on_exit() from the HasCallbacks trait. The on_exit() function is called once on unloading of the plugin.

The at exit callback exists in v1 of the plugin specification, so it has not got any "feature = plugin-api-vX" gaurds at all.

Tested using qemu-user, with the TinyTrace plugin now printing on unload. Untested on qemu-system.

Signed-off-by: Harry van Haaren <harry.vanhaaren@openchip.com>