### PR TITLE
Fix windows and macos CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
     runs-on: windows-latest
 
     env:
-      QEMU_VERSION: "10.1.0-1"
+      QEMU_VERSION: "11.0.0-1"
       RUSTUP_URL: "https://win.rustup.rs/x86_64"
       FEDORA_CLOUDIMG_URL: "https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Install QEMU Build Dependencies
         run: |
           brew update
-          brew install pkg-config glib pixman gettext meson ninja python coreutils
+          brew install pkg-config glib pixman gettext meson ninja python coreutils sphinx-doc
 
       - name: Cache QEMU
         id: qemu-cache-macos
@@ -236,7 +236,10 @@ jobs:
         if: steps.qemu-cache-macos.outputs.cache-hit != 'true'
         run: |
           cd qemu-upstream
-          ./configure --enable-plugins --target-list="x86_64-linux-user x86_64-softmmu"
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install sphinx sphinx_rtd_theme
+          ./configure --enable-plugins --target-list="x86_64-softmmu"
           make -C build -j"$(sysctl -n hw.logicalcpu)"
 
       - name: Test QEMU Install


### PR DESCRIPTION
CI issues:
* Windows is trying to install a version of qemu that isn't on msys anymore.
* macos is trying to build the x86_64-linux-user target, which is not (any more?) an option for macos.

Fix:
* update windows version
* don't try to build that target on macos
* also, it was complaining about missing sphinx-doc. Have added commands to install that, though maybe we don't need it?

Limitations:
* windows CI is going to keep breaking if we're specifying specific versions. But if we just installed whatever is there, we'd have to figure out how to know which plugin version to use. Discuss?

Fixes #39 