### PR TITLE
plugin-v6: add qemu_plugin_set_pc API

### DIFF
--- a/qemu-plugin/src/lib.rs
+++ b/qemu-plugin/src/lib.rs
@@ -958,3 +958,24 @@ pub fn qemu_plugin_u64_set(entry: PluginU64, vcpu_index: VCPUIndex, value: u64) 
 pub fn qemu_plugin_scoreboard_sum(entry: PluginU64) -> u64 {
     unsafe { crate::sys::qemu_plugin_u64_sum(entry) }
 }
+
+#[cfg(not(any(
+    feature = "plugin-api-v0",
+    feature = "plugin-api-v1",
+    feature = "plugin-api-v2",
+    feature = "plugin-api-v3",
+    feature = "plugin-api-v4",
+    feature = "plugin-api-v5"
+)))]
+/// Set the program counter for the current vCPU
+///
+/// This function never returns, as it directly hands control back to QEMU and
+/// continues guest execution at the specified address.
+///
+/// # Arguments
+///
+/// - `vaddr`: the (virtual) address at which to resume guest execution
+///
+pub fn qemu_plugin_set_pc(vaddr: u64) -> ! {
+    unsafe { crate::sys::qemu_plugin_set_pc(vaddr) };
+}


### PR DESCRIPTION
Control-flow diversion via writing the PC does not work via the original register write API, as this has no direct effect on the execution. Upstream QEMU introduced a qemu_plugin_set_pc API in version 11.0 for this purpose (see
https://lore.kernel.org/qemu-devel/20260305-setpc-v5-v7-0-4c3adba52403@epfl.ch/).

I contemplated adding a special case in the `RegisterDescriptor::write` method, but that seemed brittle and is not really mirroring upstream. For the sake of simplicity, I therefore think that exposing this API directly as I do in this PR makes more sense. Opinions welcome, however!

This is part of the changes mentioned in #43.