### PR TITLE
plugin-v6: add syscall filter API functions

### DIFF
--- a/qemu-plugin/src/lib.rs
+++ b/qemu-plugin/src/lib.rs
@@ -62,6 +62,15 @@
 #[cfg(windows)]
 mod win_link_hook;
 
+#[cfg(not(any(
+    feature = "plugin-api-v0",
+    feature = "plugin-api-v1",
+    feature = "plugin-api-v2",
+    feature = "plugin-api-v3",
+    feature = "plugin-api-v4",
+    feature = "plugin-api-v5"
+)))]
+use crate::sys::qemu_plugin_vcpu_syscall_filter_cb_t;
 use crate::sys::{
     qemu_plugin_cb_flags, qemu_plugin_id_t, qemu_plugin_insn, qemu_plugin_mem_rw,
     qemu_plugin_meminfo_t, qemu_plugin_op, qemu_plugin_simple_cb_t, qemu_plugin_tb,
@@ -209,6 +218,37 @@ pub type SyscallCallback = qemu_plugin_vcpu_syscall_cb_t;
 /// - `num`: The syscall number
 /// - `ret`: The syscall return value
 pub type SyscallReturnCallback = qemu_plugin_vcpu_syscall_ret_cb_t;
+
+#[cfg(not(any(
+    feature = "plugin-api-v0",
+    feature = "plugin-api-v1",
+    feature = "plugin-api-v2",
+    feature = "plugin-api-v3",
+    feature = "plugin-api-v4",
+    feature = "plugin-api-v5"
+)))]
+/// A callback called on Syscall entry, with the option to set the syscall's
+/// return value and skip executing it
+///
+/// # Arguments
+///
+/// - `id`: The plugin ID
+/// - `vcpu_index`: The index of the vCPU that executed the instruction
+/// - `num`: The syscall number
+/// - `a1`: The first syscall argument
+/// - `a2`: The second syscall argument
+/// - `a3`: The third syscall argument
+/// - `a4`: The fourth syscall argument
+/// - `a5`: The fifth syscall argument
+/// - `a6`: The sixth syscall argument
+/// - `a7`: The seventh syscall argument
+/// - `a8`: The eighth syscall argument
+/// - `sysret`: A pointer to the syscall return value
+///
+/// # Return value
+///
+/// * `bool`: Whether to skip executing the syscall and return the value of `sysret` instead
+pub type SyscallFilterCallback = qemu_plugin_vcpu_syscall_filter_cb_t;
 
 /// A callback called when execution has finished and the plugin should free its resources
 ///
@@ -760,6 +800,28 @@ pub fn qemu_plugin_register_vcpu_syscall_cb(id: qemu_plugin_id_t, cb: SyscallCal
 /// - `cb`: The callback to be called
 pub fn qemu_plugin_register_vcpu_syscall_ret_cb(id: qemu_plugin_id_t, cb: SyscallReturnCallback) {
     unsafe { crate::sys::qemu_plugin_register_vcpu_syscall_ret_cb(id, cb) };
+}
+
+#[cfg(not(any(
+    feature = "plugin-api-v0",
+    feature = "plugin-api-v1",
+    feature = "plugin-api-v2",
+    feature = "plugin-api-v3",
+    feature = "plugin-api-v4",
+    feature = "plugin-api-v5"
+)))]
+/// Register a callback to run on Syscall entry, with the option to set the
+/// syscall's return value and skip executing it
+///
+/// # Arguments
+///
+/// - `id`: The plugin ID
+/// - `cb`: The callback to be called
+pub fn qemu_plugin_register_vcpu_syscall_filter_cb(
+    id: qemu_plugin_id_t,
+    cb: SyscallFilterCallback,
+) {
+    unsafe { crate::sys::qemu_plugin_register_vcpu_syscall_filter_cb(id, cb) };
 }
 
 /// Output a string via the QEMU logging mechanism

--- a/qemu-plugin/src/plugin/mod.rs
+++ b/qemu-plugin/src/plugin/mod.rs
@@ -2,6 +2,15 @@
 
 use std::sync::{Mutex, OnceLock};
 
+#[cfg(not(any(
+    feature = "plugin-api-v0",
+    feature = "plugin-api-v1",
+    feature = "plugin-api-v2",
+    feature = "plugin-api-v3",
+    feature = "plugin-api-v4",
+    feature = "plugin-api-v5"
+)))]
+use crate::qemu_plugin_register_vcpu_syscall_filter_cb;
 use crate::{
     Args, Error, Info, PluginId, Result, TranslationBlock, VCPUIndex,
     qemu_plugin_register_atexit_cb, qemu_plugin_register_flush_cb,
@@ -185,6 +194,55 @@ extern "C" fn handle_qemu_plugin_register_syscall_ret_cb(
         .expect("Failed running callback on_syscall_return");
 }
 
+#[cfg(not(any(
+    feature = "plugin-api-v0",
+    feature = "plugin-api-v1",
+    feature = "plugin-api-v2",
+    feature = "plugin-api-v3",
+    feature = "plugin-api-v4",
+    feature = "plugin-api-v5"
+)))]
+/// Handler for callbacks registered via the `qemu_plugin_register_vcpu_syscall_filter_cb`
+/// function. These callbacks are called when a syscall is made in QEMU and pass the syscall number
+/// and its arguments. They also allow filtering the syscall by modifying the return value via the
+/// `sysret` reference and returning `true` to indicate the actual syscall should be skipped.
+extern "C" fn handle_qemu_plugin_register_syscall_filter_cb(
+    id: PluginId,
+    vcpu_index: VCPUIndex,
+    num: i64,
+    a1: u64,
+    a2: u64,
+    a3: u64,
+    a4: u64,
+    a5: u64,
+    a6: u64,
+    a7: u64,
+    a8: u64,
+    sysret: *mut u64,
+) -> bool {
+    let Some(plugin) = PLUGIN.get() else {
+        panic!("Plugin not set");
+    };
+
+    let Ok(mut plugin) = plugin.lock() else {
+        panic!("Failed to lock plugin");
+    };
+
+    // SAFETY: QEMU's code is paused (i.e., higher up the call stack) while this callback is
+    // running, so there are no concurrent accesses to the `sysret` pointer. This pointer is a
+    // pointer to a stack variable in QEMU's code, so it's guaranteed to be valid and alive for the
+    // duration of this callback.
+    let Some(sysret) = (unsafe { sysret.as_mut() }) else {
+        // This should never happen, since QEMU always passes a valid stack pointer. Just to be on
+        // the safe side, let's panic here.
+        panic!("sysret pointer is null");
+    };
+
+    plugin
+        .on_syscall_filter(id, vcpu_index, num, a1, a2, a3, a4, a5, a6, a7, a8, sysret)
+        .expect("Failed running callback on_syscall_filter")
+}
+
 /// Trait which implemenents registering the callbacks implemented on a struct which
 /// `HasCallbacks` with QEMU
 ///
@@ -276,6 +334,19 @@ pub trait Register: HasCallbacks + Send + Sync + 'static {
         qemu_plugin_register_vcpu_syscall_ret_cb(
             id,
             Some(handle_qemu_plugin_register_syscall_ret_cb),
+        );
+
+        #[cfg(not(any(
+            feature = "plugin-api-v0",
+            feature = "plugin-api-v1",
+            feature = "plugin-api-v2",
+            feature = "plugin-api-v3",
+            feature = "plugin-api-v4",
+            feature = "plugin-api-v5"
+        )))]
+        qemu_plugin_register_vcpu_syscall_filter_cb(
+            id,
+            Some(handle_qemu_plugin_register_syscall_filter_cb),
         );
 
         self.register(id, args, info)?;
@@ -450,6 +521,53 @@ pub trait HasCallbacks: Send + Sync + 'static {
         ret: i64,
     ) -> Result<()> {
         Ok(())
+    }
+
+    #[cfg(not(any(
+        feature = "plugin-api-v0",
+        feature = "plugin-api-v1",
+        feature = "plugin-api-v2",
+        feature = "plugin-api-v3",
+        feature = "plugin-api-v4",
+        feature = "plugin-api-v5"
+    )))]
+    #[allow(unused, clippy::too_many_arguments)]
+    /// Callback triggered on syscall, allows filtering the syscall
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The ID of the plugin
+    /// * `vcpu_index` - The ID of the vCPU
+    /// * `num` - The syscall number
+    /// * `a1` - The first syscall argument
+    /// * `a2` - The second syscall argument
+    /// * `a3` - The third syscall argument
+    /// * `a4` - The fourth syscall argument
+    /// * `a5` - The fifth syscall argument
+    /// * `a6` - The sixth syscall argument
+    /// * `a7` - The seventh syscall argument
+    /// * `a8` - The eighth syscall argument
+    /// - `sysret`: A mutable reference to the syscall return value
+    ///
+    /// # Return value
+    ///
+    /// * `bool`: Whether to skip executing the syscall and return the value of `sysret` instead
+    fn on_syscall_filter(
+        &mut self,
+        id: PluginId,
+        vcpu_index: VCPUIndex,
+        num: i64,
+        a1: u64,
+        a2: u64,
+        a3: u64,
+        a4: u64,
+        a5: u64,
+        a6: u64,
+        a7: u64,
+        a8: u64,
+        sysret: &mut u64,
+    ) -> Result<bool> {
+        Ok(false)
     }
 }
 

--- a/qemu-plugin/src/plugin/mod.rs
+++ b/qemu-plugin/src/plugin/mod.rs
@@ -2,15 +2,6 @@
 
 use std::sync::{Mutex, OnceLock};
 
-#[cfg(not(any(
-    feature = "plugin-api-v0",
-    feature = "plugin-api-v1",
-    feature = "plugin-api-v2",
-    feature = "plugin-api-v3",
-    feature = "plugin-api-v4",
-    feature = "plugin-api-v5"
-)))]
-use crate::qemu_plugin_register_vcpu_syscall_filter_cb;
 use crate::{
     Args, Error, Info, PluginId, Result, TranslationBlock, VCPUIndex,
     qemu_plugin_register_atexit_cb, qemu_plugin_register_flush_cb,
@@ -19,6 +10,15 @@ use crate::{
     qemu_plugin_register_vcpu_syscall_cb, qemu_plugin_register_vcpu_syscall_ret_cb,
     qemu_plugin_register_vcpu_tb_trans_cb,
 };
+#[cfg(not(any(
+    feature = "plugin-api-v0",
+    feature = "plugin-api-v1",
+    feature = "plugin-api-v2",
+    feature = "plugin-api-v3",
+    feature = "plugin-api-v4",
+    feature = "plugin-api-v5"
+)))]
+use {crate::qemu_plugin_register_vcpu_syscall_filter_cb, std::ops::ControlFlow};
 
 /// Handler for callbacks registered via the `qemu_plugin_register_vcpu_init_cb`
 /// function. These callbacks are called when a vCPU is initialized in QEMU (in softmmu
@@ -228,19 +228,22 @@ extern "C" fn handle_qemu_plugin_register_syscall_filter_cb(
         panic!("Failed to lock plugin");
     };
 
-    // SAFETY: QEMU's code is paused (i.e., higher up the call stack) while this callback is
-    // running, so there are no concurrent accesses to the `sysret` pointer. This pointer is a
-    // pointer to a stack variable in QEMU's code, so it's guaranteed to be valid and alive for the
-    // duration of this callback.
-    let Some(sysret) = (unsafe { sysret.as_mut() }) else {
-        // This should never happen, since QEMU always passes a valid stack pointer. Just to be on
-        // the safe side, let's panic here.
-        panic!("sysret pointer is null");
-    };
-
-    plugin
-        .on_syscall_filter(id, vcpu_index, num, a1, a2, a3, a4, a5, a6, a7, a8, sysret)
+    match plugin
+        .on_syscall_filter(id, vcpu_index, num, a1, a2, a3, a4, a5, a6, a7, a8)
         .expect("Failed running callback on_syscall_filter")
+    {
+        ControlFlow::Continue(()) => false,
+        ControlFlow::Break(retval) => {
+            // SAFETY: QEMU's code is paused (i.e., higher up the call stack) while this callback is
+            // running, so there are no concurrent accesses to the `sysret` pointer. This pointer is a
+            // pointer to a stack variable in QEMU's code, so it's guaranteed to be valid and alive for the
+            // duration of this callback.
+            unsafe {
+                *sysret = retval;
+            }
+            true
+        }
+    }
 }
 
 /// Trait which implemenents registering the callbacks implemented on a struct which
@@ -547,11 +550,12 @@ pub trait HasCallbacks: Send + Sync + 'static {
     /// * `a6` - The sixth syscall argument
     /// * `a7` - The seventh syscall argument
     /// * `a8` - The eighth syscall argument
-    /// - `sysret`: A mutable reference to the syscall return value
     ///
     /// # Return value
     ///
-    /// * `bool`: Whether to skip executing the syscall and return the value of `sysret` instead
+    /// * `ControlFlow<u64>`: Whether to skip executing the syscall and return the wrapped
+    ///   value of `ControlFlow::Break(u64)` instead, or to continue executing the syscall
+    ///   with `ControlFlow::Continue(())`.
     fn on_syscall_filter(
         &mut self,
         id: PluginId,
@@ -565,9 +569,8 @@ pub trait HasCallbacks: Send + Sync + 'static {
         a6: u64,
         a7: u64,
         a8: u64,
-        sysret: &mut u64,
-    ) -> Result<bool> {
-        Ok(false)
+    ) -> Result<ControlFlow<u64>> {
+        Ok(ControlFlow::Continue(()))
     }
 }
 


### PR DESCRIPTION
The syscall filter API allows to set a syscall's return value and skip actually executing it. This functionality was introduced in QEMU 11.0 in the patchset here:
https://lore.kernel.org/qemu-devel/20260129013134.3956938-1-pierrick.bouvier@linaro.org/

This is part of the changes mentioned in #43.